### PR TITLE
Update chatCompletion args

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -47,7 +47,7 @@ const response = await client.ai.createChatCompletion({
   messages: [
     {
       role: "user",
-      content: "What companies have both paradigm and multicoin on their cap table?",
+      content: "What companies have both paradigm and a16z on their cap table?",
     },
   ],
 });

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@messari/sdk",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"private": false,
 	"description": "Messari SDK provides a type-safe, intuitive interface for accessing Messari's suite of crypto data and AI APIs.",
 	"author": "Messari Engineering",

--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -27,7 +27,7 @@ export const createChatCompletion = {
   method: 'POST' as const,
   pathParams: [] as const,
   queryParams: [] as const,
-  bodyParams: ['messages', 'verbosity', 'response_format', 'stream'] as const,
+  bodyParams: ['messages', 'verbosity', 'response_format', 'inline_citations'] as const,
   path: () => '/ai/v1/chat/completions'
 } as const;
 

--- a/packages/api/src/types/types.ts
+++ b/packages/api/src/types/types.ts
@@ -575,23 +575,23 @@ export type components = {
       role: "system" | "user" | "assistant";
     };
     ChatCompletionRequest: {
+      /**
+       * @description Whether to include inline citations in the response
+       * @default false
+       */
+      inline_citations?: boolean;
       /** @description Array of messages in the conversation */
       messages: components["schemas"]["ChatCompletionMessage"][];
       /**
        * @description Desired format of the response
        * @enum {string}
        */
-      response_format?: "text" | "json" | "markdown";
-      /**
-       * @description Whether to stream the response
-       * @default false
-       */
-      stream?: boolean;
+      response_format?: "markdown" | "plaintext";
       /**
        * @description Controls how verbose the response should be
        * @enum {string}
        */
-      verbosity?: "concise" | "normal" | "detailed";
+      verbosity?: "succinct" | "balanced" | "verbose";
     };
     ChatCompletionResponse: {
       /** @description Array of response messages */

--- a/packages/examples/src/ai.ts
+++ b/packages/examples/src/ai.ts
@@ -25,16 +25,19 @@ async function main() {
     console.log("AI Chat Completion");
     console.log("--------------------------------");
     console.log("Sending request...");
-    console.log(`"What companies have both paradigm and multicoin on their cap table?"`);
+    console.log(`"What companies have both paradigm and a16z on their cap table?"`);
 
     // Call the createChatCompletion endpoint
     const response = await client.ai.createChatCompletion({
       messages: [
         {
           role: "user",
-          content: "What companies have both Paradigm and a16z on their cap table?",
+          content: "What companies have both paradigm and a16z on their cap table?",
         },
       ],
+      verbosity: "succinct",
+      response_format: "plaintext",
+      inline_citations: false,
     });
 
     const assistantMessage = response.messages[0].content;

--- a/typegen/openapi/services/ai/openapi.yaml
+++ b/typegen/openapi/services/ai/openapi.yaml
@@ -152,16 +152,16 @@ components:
           description: Array of messages in the conversation
         verbosity:
           type: string
-          enum: [concise, normal, detailed]
+          enum: [succinct, balanced, verbose]
           description: Controls how verbose the response should be
         response_format:
           type: string
-          enum: [text, json, markdown]
+          enum: [markdown, plaintext]
           description: Desired format of the response
-        stream:
+        inline_citations:
           type: boolean
           default: false
-          description: Whether to stream the response
+          description: Whether to include inline citations in the response
 
     ChatCompletionResponse:
       type: object


### PR DESCRIPTION
## Title
Update chatCompletion args

## Description
Update enums for `verbosity` and `response_format`. Remove `stream` arg for now. Standardize example questions

## Type of change
<!--- Select from the options presented below (delete non-relevant options) -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Related PRs
<!--- Please link to the other related PRs here: -->

## How can a reviewer test this code?
<!--- Please describe in succinct, clear steps how a reviewer can test your changes. -->

## Screenshots (if appropriate):
<!--- Appropriate screenshots for this repo include the logs from a successful partial -->
<!--- service run OR DB records that have been successfully repopulated. -->
